### PR TITLE
Refactor diet as boolean

### DIFF
--- a/src/@types/navigation.d.ts
+++ b/src/@types/navigation.d.ts
@@ -3,15 +3,17 @@ export declare global {
     interface RootParamList {
       home: undefined;
       statistics: undefined;
-      newMeal: {
-        meal: string;
-        description: string;
-        hour: string;
-        date: string;
-        diet: string;
-      } | undefined;
+      newMeal:
+        | {
+            meal: string;
+            description: string;
+            hour: string;
+            date: string;
+            diet: boolean;
+          }
+        | undefined;
       feedback: {
-        diet: string;
+        diet: boolean;
       };
       meal: {
         item: {
@@ -19,7 +21,7 @@ export declare global {
           description: string;
           hour: string;
           date: string;
-          diet: string;
+          diet: boolean;
         };
       };
     }

--- a/src/components/Meal/index.tsx
+++ b/src/components/Meal/index.tsx
@@ -5,7 +5,7 @@ import { Container, Dot, Hour, MealTitle, Separator } from "./styles";
 type Props = {
   hour: string;
   meal: string;
-  diet: string;
+  diet: boolean;
   onPress: () => void;
 };
 

--- a/src/components/Meal/styles.ts
+++ b/src/components/Meal/styles.ts
@@ -4,7 +4,7 @@ import theme from "../../theme";
 import { Label } from "../Ui/styles";
 
 type DotProps = {
-  diet: string;
+  diet: boolean;
 };
 
 export const Container = styled(TouchableOpacity).attrs(() => ({
@@ -41,7 +41,7 @@ export const Dot = styled.View<DotProps>`
   width: 14px;
   height: 14px;
   background-color: ${({ theme, diet }) =>
-    diet === "yes" ? theme.COLORS.green_mid : theme.COLORS.red_mid};
+    diet ? theme.COLORS.green_mid : theme.COLORS.red_mid};
   border-radius: 8px;
   margin-left: auto;
 `;

--- a/src/components/Options/index.tsx
+++ b/src/components/Options/index.tsx
@@ -4,12 +4,13 @@ import { Label } from "../Ui/styles";
 import { Container, Icon, Option, Type } from "./styles";
 
 type Props = {
-  diet: string;
-  setDiet: (type: string) => void;
+  diet: boolean | null;
+  setDiet: (type: boolean) => void;
 };
 
 export default function Options({ diet, setDiet }: Props) {
   const { FONT_SIZE, COLORS } = useTheme();
+  const hasSelection = diet !== null;
 
   return (
     <Container>
@@ -20,8 +21,9 @@ export default function Options({ diet, setDiet }: Props) {
       <Option>
         <Type
           style={{ marginRight: 8 }}
-          selected={diet === "yes" ? "yes" : ""}
-          onPress={() => setDiet("yes")}
+          variant="green"
+          selected={hasSelection && diet}
+          onPress={() => setDiet(true)}
         >
           <Icon name="dot-fill" size={16} color={COLORS.green_dark} />
           <Label bold size={FONT_SIZE.SM} color={COLORS.gray_100}>
@@ -29,8 +31,9 @@ export default function Options({ diet, setDiet }: Props) {
           </Label>
         </Type>
         <Type
-          selected={diet === "no" ? "no" : ""}
-          onPress={() => setDiet("no")}
+          selected={hasSelection && !diet}
+          variant="red"
+          onPress={() => setDiet(false)}
         >
           <Icon name="dot-fill" size={16} color={COLORS.red_dark} />
           <Label bold size={FONT_SIZE.SM} color={COLORS.gray_100}>

--- a/src/components/Options/styles.ts
+++ b/src/components/Options/styles.ts
@@ -3,7 +3,8 @@ import { Octicons } from "@expo/vector-icons";
 import { TouchableOpacity } from "react-native";
 
 export type TypeProps = {
-  selected: string;
+  selected: boolean;
+  variant: "green" | "red";
 };
 
 export const Container = styled.View`
@@ -28,19 +29,19 @@ export const Type = styled(TouchableOpacity).attrs(() => ({
   padding: 16px;
   border-radius: 6px;
 
-  ${({ theme, selected }) =>
+  ${({ theme, selected, variant }) =>
     css`
       border: 1px solid
-        ${selected === "yes"
+        ${!selected
+          ? theme.COLORS.gray_600
+          : variant === "green"
           ? theme.COLORS.green_dark
-          : selected === "no"
-          ? theme.COLORS.red_dark
-          : theme.COLORS.gray_600};
-      background-color: ${selected === "yes"
+          : theme.COLORS.red_dark};
+      background-color: ${!selected
+        ? theme.COLORS.gray_600
+        : variant === "green"
         ? theme.COLORS.green_light
-        : selected === "no"
-        ? theme.COLORS.red_light
-        : theme.COLORS.gray_600};
+        : theme.COLORS.red_light};
     `}
 `;
 

--- a/src/screens/Feedback/index.tsx
+++ b/src/screens/Feedback/index.tsx
@@ -8,7 +8,7 @@ import { Label } from "../../components/Ui/styles";
 import { Container, Img } from "./styles";
 
 type RouteParams = {
-  diet: string;
+  diet: boolean;
 };
 
 export default function Feedback() {
@@ -50,7 +50,5 @@ export default function Feedback() {
     </>
   );
 
-  return (
-    <Container>{diet === "yes" ? goodFeedback() : badFeedback()}</Container>
-  );
+  return <Container>{diet ? goodFeedback() : badFeedback()}</Container>;
 }

--- a/src/screens/Meal/index.tsx
+++ b/src/screens/Meal/index.tsx
@@ -15,7 +15,7 @@ type RouteParams = {
     description: string;
     hour: string;
     date: string;
-    diet: string;
+    diet: boolean;
   };
 };
 
@@ -62,7 +62,7 @@ export default function Meal() {
           <Pin>
             <Dot diet={item.diet} />
             <Label color={COLORS.gray_100} size={FONT_SIZE.SM}>
-              {item.diet === "yes" ? "dentro da dieta" : "fora da dieta"}
+              {item.diet ? "dentro da dieta" : "fora da dieta"}
             </Label>
           </Pin>
 

--- a/src/screens/Meal/styles.ts
+++ b/src/screens/Meal/styles.ts
@@ -2,17 +2,17 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
 
 type ContainerProps = {
-  inDiet: string;
+  inDiet: boolean;
 };
 
 type DotProps = {
-  diet: string;
+  diet: boolean;
 };
 
 export const Container = styled(SafeAreaView)<ContainerProps>`
   flex: 1;
   background-color: ${({ theme, inDiet }) =>
-    inDiet === "yes" ? theme.COLORS.green_light : theme.COLORS.red_light};
+    inDiet ? theme.COLORS.green_light : theme.COLORS.red_light};
 `;
 
 export const Pin = styled.View`
@@ -28,7 +28,7 @@ export const Dot = styled.View<DotProps>`
   width: 8px;
   height: 8px;
   background-color: ${({ theme, diet }) =>
-    diet === "yes" ? theme.COLORS.green_dark : theme.COLORS.red_dark};
+    diet ? theme.COLORS.green_dark : theme.COLORS.red_dark};
   border-radius: 8px;
   margin-right: 8px;
 `;

--- a/src/screens/NewMeal/index.tsx
+++ b/src/screens/NewMeal/index.tsx
@@ -19,7 +19,7 @@ type RouteParams = {
   description: string;
   hour: string;
   date: string;
-  diet: string;
+  diet: boolean | null;
 };
 
 export default function NewMeal() {
@@ -30,7 +30,7 @@ export default function NewMeal() {
   const [description, setDescription] = useState("");
   const [date, setDate] = useState("");
   const [hour, setHour] = useState("");
-  const [diet, setDiet] = useState("");
+  const [diet, setDiet] = useState<boolean | null>(null);
 
   useEffect(() => {
     if (item) {

--- a/src/storage/MealStorageDTO.ts
+++ b/src/storage/MealStorageDTO.ts
@@ -6,7 +6,7 @@ export type MealStorageDTO = {
       description: string;
       hour: string;
       date: string;
-      diet: string;
+      diet: boolean;
     }
   ];
 };

--- a/src/storage/deleteMeal.ts
+++ b/src/storage/deleteMeal.ts
@@ -8,7 +8,7 @@ type Props = {
   description: string;
   hour: string;
   date: string;
-  diet: string;
+  diet: boolean;
 };
 
 export async function DeleteMeal(meal: Props) {
@@ -16,10 +16,10 @@ export async function DeleteMeal(meal: Props) {
     let allMeals = await getAllMeals();
 
     const filteredAllMeals = allMeals
-      .map((item: MealStorageDTO) => item.data.map(itemData => itemData))
-      .map(subarr =>
+      .map((item: MealStorageDTO) => item.data.map((itemData) => itemData))
+      .map((subarr) =>
         subarr.filter(
-          item =>
+          (item) =>
             item.meal !== meal.meal ||
             item.description !== meal.description ||
             item.hour !== meal.hour ||

--- a/src/storage/editMeal.ts
+++ b/src/storage/editMeal.ts
@@ -7,7 +7,7 @@ type Props = {
   description: string;
   hour: string;
   date: string;
-  diet: string;
+  diet: boolean;
 };
 
 export async function EditMeal(oldMeal: Props, meal: MealStorageDTO) {

--- a/src/storage/statisticsMeals.ts
+++ b/src/storage/statisticsMeals.ts
@@ -6,19 +6,19 @@ export async function statisticsMeals() {
     const allMeals = await getAllMeals();
 
     const dataMap = allMeals.map((item: MealStorageDTO) =>
-      item.data.map(itemData => itemData)
+      item.data.map((itemData) => itemData)
     );
 
     const flatMap = dataMap.flat();
 
     function rowInsideDiet() {
-      const dietFlat = flatMap.map(item => item.diet);
+      const dietFlat = flatMap.map((item) => item.diet);
 
       let maxInRow = 0;
       let streak = 0;
 
       for (const element of dietFlat) {
-        if (element === "yes") {
+        if (element) {
           streak++;
           maxInRow = Math.max(maxInRow, streak);
         } else {
@@ -30,7 +30,7 @@ export async function statisticsMeals() {
     }
 
     function countRegisteredMeals() {
-      const dataArrayMapLength = dataMap.map(item => item.length);
+      const dataArrayMapLength = dataMap.map((item) => item.length);
 
       const sumRegisteredMeals = dataArrayMapLength.reduce(
         (total: number, item: number) => total + item,
@@ -41,9 +41,9 @@ export async function statisticsMeals() {
     }
 
     function countInsideAndOutDiet() {
-      const mealsInside = flatMap.filter(item => item.diet === "yes").length;
+      const mealsInside = flatMap.filter((item) => item.diet).length;
 
-      const mealsOutside = flatMap.filter(item => item.diet === "no").length;
+      const mealsOutside = flatMap.filter((item) => !item.diet).length;
 
       return { mealsInside, mealsOutside };
     }


### PR DESCRIPTION
Fala @MarcosVel,

Aqui está minha solução para usar o valor `diet` como boolean.

Saiba que eu não tenho um contexto geral da aplicação mas eu fiz o melhor para que minha mudança reflita em todos os níveis da aplicação. 

Você precisa deletar qualquer `Meal` que esteja em seu estado para essa solução funcionar. Se você tiver meals que estejam persistida como `string` ela não será mostrada com o status correto.

A mudança principal é encontrada nesse commit:  b5f275d83567692cca0485b0e3f3a14470bd699f


Eu explicarei em mais detalhes como comentários nesse PR.
